### PR TITLE
Change to enable Wazuh Agent service

### DIFF
--- a/bnc-siem-suite.sh
+++ b/bnc-siem-suite.sh
@@ -604,7 +604,10 @@ sca.remote_commands=1
 
 # Restart the Wazuh agent (and Osquery subagent)
 if [[ `which systemctl 2> /dev/null` ]]; then
-        systemctl restart wazuh-agent
+        systemctl stop wazuh-agent
+	systemctl daemon-reload
+	systemctl enable wazuh-agent
+	systemctl start wazuh-agent
 else
         service wazuh-agent restart
 fi


### PR DESCRIPTION
Fixing script to align with change in default behavior of wazuh-agent installation package that does not enable the Wazuh service.