### PR TITLE
Adding stop of osqueryd service to uninstallsuite

### DIFF
--- a/bnc-siem-suite.ps1
+++ b/bnc-siem-suite.ps1
@@ -483,7 +483,9 @@ function uninstallSuite {
 	If ( -not ($SkipOsquery) ) {
 		if (Test-Path "c:\Program Files\osquery\osqueryd\osqueryd.exe" -PathType leaf)  {
 			if ($Debug) { Write-Output "Removing Osquery..." }
-			Uninstall-Package -Name "osquery" -erroraction 'silentlycontinue' | out-null
+                        # The osqueryd service is not always stopped during uninstall process and may be left behind causing the script to fail
+			Stop-Service osqueryd | out-null
+                        Uninstall-Package -Name "osquery" -erroraction 'silentlycontinue' | out-null
 			Remove-Item "C:\Progra~1\osquery" -recurse -erroraction 'silentlycontinue'
 		}
 		if (Test-Path "c:\Program Files\osquery\osqueryd\osqueryd.exe" -PathType leaf)  {


### PR DESCRIPTION
Sometimes osqueryd does not stop during uninstall process, causing the script to fail and bail.